### PR TITLE
Added options for 64bit and out-of-path executables

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,7 @@ should be:
 * PROJECT (your projects name?)
 * TOP_LEVEL_ENTITY (your projects top level entity)
 * FAMILY, PART and BOARDFILE (for pin assignments, and part selection)
+* QUARTUS_PATH (path to the bin/ directory of the desired quartus version)
 
 Now you can create and build your project by::
 
@@ -37,7 +38,7 @@ Now you can create and build your project by::
  
 In order to program the FPGA device use::
 
-  user$: make program
+  user$: make -C quartus program
 
 Known problems
 ~~~~~~~~~~~~~~~

--- a/fpga/top_level.v
+++ b/fpga/top_level.v
@@ -1,5 +1,0 @@
-module top_level (input CLOCK_50);
-
-// This is a template
-
-endmodule

--- a/quartus/DE1.mk
+++ b/quartus/DE1.mk
@@ -1,0 +1,2 @@
+FAMILY = "Cyclone II"
+PART = EP2C20F484C7

--- a/quartus/DE2.mk
+++ b/quartus/DE2.mk
@@ -1,0 +1,2 @@
+FAMILY = "Cyclone II"
+PART = EP2C35F672C6

--- a/quartus/DE2Pins
+++ b/quartus/DE2Pins
@@ -1,5 +1,4 @@
 
-
 # These are the pin assignments for the Altera DE2
 set_location_assignment PIN_N25 -to SW[0]
 set_location_assignment PIN_N26 -to SW[1]
@@ -426,3 +425,6 @@ set_location_assignment PIN_V24 -to GPIO_1[32]
 set_location_assignment PIN_V23 -to GPIO_1[33]
 set_location_assignment PIN_W25 -to GPIO_1[34]
 set_location_assignment PIN_W23 -to GPIO_1[35]
+
+set_global_assignment -name CYCLONEII_RESERVE_NCEO_AFTER_CONFIGURATION "USE AS REGULAR IO"
+set_global_assignment -name RESERVE_ASDO_AFTER_CONFIGURATION "USE AS REGULAR IO"

--- a/quartus/Makefile
+++ b/quartus/Makefile
@@ -44,6 +44,10 @@ smart: smart.log
 # Executable Configuration
 ###################################################################
 
+ifeq ($(shell uname -m),x86_64)
+QUARTUS_ARGS = --64bit
+endif
+
 MAP_ARGS = $(QUARTUS_ARGS) --read_settings_files=on $(addprefix --source=,$(SRCS))
 FIT_ARGS = $(QUARTUS_ARGS) --part=$(PART) --read_settings_files=on
 ASM_ARGS = $(QUARTUS_ARGS)

--- a/quartus/Makefile
+++ b/quartus/Makefile
@@ -32,7 +32,7 @@ SRCS = ../fpga/top_level.v \
 all: smart.log $(PROJECT).asm.rpt $(PROJECT).sta.rpt 
 
 clean:
-	rm -rf *.rpt *.chg smart.log *.htm *.eqn *.pin *.sof *.pof db incremental_db
+	$(RM) *.rpt *.chg smart.log *.htm *.eqn *.pin *.sof *.pof db incremental_db *.summary *.smsg *.jdi $(ASSIGNMENT_FILES)
 
 map: smart.log $(PROJECT).map.rpt
 fit: smart.log $(PROJECT).fit.rpt

--- a/quartus/Makefile
+++ b/quartus/Makefile
@@ -18,8 +18,11 @@ BOARDFILE = DE2Pins
 
 ###################################################################
 # Setup your sources here
-SRCS = ../fpga/top_level.v \
-       ../fpga/nios.qsys
+SRCS = $(wildcard ../fpga/*.sv) \
+  $(wildcard ../fpga/*.v) \
+  $(wildcard ../fpga/*.vhdl) \
+  $(wildcard ../fpga/*.vhd) \
+  $(wildcard ../fpga/*.qsys)
 
 ###################################################################
 # Main Targets

--- a/quartus/Makefile
+++ b/quartus/Makefile
@@ -42,7 +42,20 @@ smart: smart.log
 
 ###################################################################
 # Executable Configuration
+#
+# QUARTUS_PATH: If empty then system path is searched.
+#               If set then requires trailling slash.
+#               Commented out so it may be set from environment.
 ###################################################################
+
+# QUARTUS_PATH = /opt/altera/13.0sp1/quartus/bin/
+
+QUARTUS_MAP  = $(QUARTUS_PATH)quartus_map
+QUARTUS_FIT  = $(QUARTUS_PATH)quartus_fit
+QUARTUS_ASM  = $(QUARTUS_PATH)quartus_asm
+QUARTUS_STA  = $(QUARTUS_PATH)quartus_sta
+QUARTUS_SH   = $(QUARTUS_PATH)quartus_sh
+QUARTUS_PGM  = $(QUARTUS_PATH)quartus_pgm
 
 ifeq ($(shell uname -m),x86_64)
 QUARTUS_ARGS = --64bit
@@ -62,29 +75,29 @@ PGM_ARGS = $(QUARTUS_ARGS) --no_banner --mode=jtag
 STAMP = echo done >
 
 $(PROJECT).map.rpt: map.chg $(SOURCE_FILES) 
-	quartus_map $(MAP_ARGS) $(PROJECT)
+	$(QUARTUS_MAP) $(MAP_ARGS) $(PROJECT)
 	$(STAMP) fit.chg
 
 $(PROJECT).fit.rpt: fit.chg $(PROJECT).map.rpt
-	quartus_fit $(FIT_ARGS) $(PROJECT)
+	$(QUARTUS_FIT) $(FIT_ARGS) $(PROJECT)
 	$(STAMP) asm.chg
 	$(STAMP) sta.chg
 
 $(PROJECT).asm.rpt: asm.chg $(PROJECT).fit.rpt
-	quartus_asm $(ASM_ARGS) $(PROJECT)
+	$(QUARTUS_ASM) $(ASM_ARGS) $(PROJECT)
 
 $(PROJECT).sta.rpt: sta.chg $(PROJECT).fit.rpt
-	quartus_sta $(STA_ARGS) $(PROJECT) 
+	$(QUARTUS_STA) $(STA_ARGS) $(PROJECT) 
 
 smart.log: $(ASSIGNMENT_FILES)
-	quartus_sh $(SH_ARGS) --determine_smart_action $(PROJECT) > smart.log
+	$(QUARTUS_SH) $(SH_ARGS) --determine_smart_action $(PROJECT) > smart.log
 
 ###################################################################
 # Project initialization
 ###################################################################
 
 $(ASSIGNMENT_FILES):
-	quartus_sh $(SH_ARGS) --prepare -f $(FAMILY) -t $(TOP_LEVEL_ENTITY) $(PROJECT)
+	$(QUARTUS_SH) $(SH_ARGS) --prepare -f $(FAMILY) -t $(TOP_LEVEL_ENTITY) $(PROJECT)
 	-cat $(BOARDFILE) >> $(PROJECT).qsf
 map.chg:
 	$(STAMP) map.chg
@@ -100,7 +113,7 @@ asm.chg:
 ###################################################################
 
 program: $(PROJECT).sof
-	quartus_pgm $(PGM_ARGS) -o "P;$(PROJECT).sof"
+	$(QUARTUS_PGM) $(PGM_ARGS) -o "P;$(PROJECT).sof"
 
 program-pof: $(PROJECT).pof
-	quartus_pgm $(PGM_ARGS) -o "BVP;$(PROJECT).pof"
+	$(QUARTUS_PGM) $(PGM_ARGS) -o "BVP;$(PROJECT).pof"

--- a/quartus/Makefile
+++ b/quartus/Makefile
@@ -35,7 +35,7 @@ SRCS = $(wildcard ../fpga/*.sv) \
 all: smart.log $(PROJECT).asm.rpt $(PROJECT).sta.rpt 
 
 clean:
-	$(RM) *.rpt *.chg smart.log *.htm *.eqn *.pin *.sof *.pof db incremental_db *.summary *.smsg *.jdi $(ASSIGNMENT_FILES)
+	$(RM) -rf *.rpt *.chg smart.log *.htm *.eqn *.pin *.sof *.pof db incremental_db *.summary *.smsg *.jdi $(ASSIGNMENT_FILES)
 
 map: smart.log $(PROJECT).map.rpt
 fit: smart.log $(PROJECT).fit.rpt

--- a/quartus/Makefile
+++ b/quartus/Makefile
@@ -44,11 +44,12 @@ smart: smart.log
 # Executable Configuration
 ###################################################################
 
-MAP_ARGS = --read_settings_files=on $(addprefix --source=,$(SRCS))
-
-FIT_ARGS = --part=$(PART) --read_settings_files=on
-ASM_ARGS =
-STA_ARGS =
+MAP_ARGS = $(QUARTUS_ARGS) --read_settings_files=on $(addprefix --source=,$(SRCS))
+FIT_ARGS = $(QUARTUS_ARGS) --part=$(PART) --read_settings_files=on
+ASM_ARGS = $(QUARTUS_ARGS)
+STA_ARGS = $(QUARTUS_ARGS)
+SH_ARGS  = $(QUARTUS_ARGS)
+PGM_ARGS = $(QUARTUS_ARGS) --no_banner --mode=jtag 
 
 ###################################################################
 # Target implementations
@@ -72,14 +73,14 @@ $(PROJECT).sta.rpt: sta.chg $(PROJECT).fit.rpt
 	quartus_sta $(STA_ARGS) $(PROJECT) 
 
 smart.log: $(ASSIGNMENT_FILES)
-	quartus_sh --determine_smart_action $(PROJECT) > smart.log
+	quartus_sh $(SH_ARGS) --determine_smart_action $(PROJECT) > smart.log
 
 ###################################################################
 # Project initialization
 ###################################################################
 
 $(ASSIGNMENT_FILES):
-	quartus_sh --prepare -f $(FAMILY) -t $(TOP_LEVEL_ENTITY) $(PROJECT)
+	quartus_sh $(SH_ARGS) --prepare -f $(FAMILY) -t $(TOP_LEVEL_ENTITY) $(PROJECT)
 	-cat $(BOARDFILE) >> $(PROJECT).qsf
 map.chg:
 	$(STAMP) map.chg
@@ -95,7 +96,7 @@ asm.chg:
 ###################################################################
 
 program: $(PROJECT).sof
-	quartus_pgm --no_banner --mode=jtag -o "P;$(PROJECT).sof"
+	quartus_pgm $(PGM_ARGS) -o "P;$(PROJECT).sof"
 
 program-pof: $(PROJECT).pof
-        quartus_pgm --no_banner --mode=jtag -o "BVP;$(PROJECT).pof"
+	quartus_pgm $(PGM_ARGS) -o "BVP;$(PROJECT).pof"

--- a/quartus/openocd-DE2.cfg
+++ b/quartus/openocd-DE2.cfg
@@ -1,0 +1,3 @@
+source [find interface/altera-usb-blaster.cfg]
+jtag newtap ep2c35 tap -expected-id 0x020b40dd -irlen 10
+init


### PR DESCRIPTION
I am considering Quartus II 13.0sp1, which is the latest (OLD) version supporting the DE2 board.

- Adding command line flag --64bit is required on most current x86_64 systems.
- It is not usually on the system PATH as there are newer versions available. Setting per-project seems useful.